### PR TITLE
changed hardcoded size l to xl, when preloading images.

### DIFF
--- a/www-workspace/spa/src/app/services/http.service.ts
+++ b/www-workspace/spa/src/app/services/http.service.ts
@@ -354,7 +354,7 @@ export class HttpService {
     attemptPreload(iFileIndex) {
         // todo
 
-        let sSize = 'l';
+        let sSize = 'xl';
         var imgPreload = new Image();
     	imgPreload.src = 'https://s3-eu-west-1.amazonaws.com/picili-bucket/t/'+ this.gbl.sCurrentPageUsername +'/' + sSize + this.searchService.mData.search.results[iFileIndex].id+'.jpg'
     }


### PR DESCRIPTION
close https://github.com/samthomson/picili/issues/21

lightbox is hardcoded to show xl image, preloaders were loading l images. until the lightbox using responsive loading, this is fine.